### PR TITLE
Make `illuminatedChunks` use `LongSet` in hopes to speed it ups

### DIFF
--- a/src/main/java/lumien/randomthings/handler/spectreilluminator/SpectreIlluminationClientHandler.java
+++ b/src/main/java/lumien/randomthings/handler/spectreilluminator/SpectreIlluminationClientHandler.java
@@ -1,8 +1,7 @@
 package lumien.randomthings.handler.spectreilluminator;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import lumien.randomthings.util.WorldUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.math.BlockPos;
@@ -11,7 +10,7 @@ import net.minecraft.world.chunk.Chunk;
 
 public class SpectreIlluminationClientHandler
 {
-	static Set<Long> illuminatedChunks = new HashSet<Long>();
+	static LongSet illuminatedChunks = new LongOpenHashSet();
 	
 	public static boolean isIlluminated(BlockPos pos)
 	{


### PR DESCRIPTION
This is a much better fit, as it removes any boxing entirely.


Before (to prove that optimizing this is worth it):
<img width="1642" height="85" alt="image" src="https://github.com/user-attachments/assets/6a1f0185-5cf1-4a1d-bb16-44ccdcb975e5" />