### PR TITLE
Fix CustomClassWriter crash on Java 9+

### DIFF
--- a/src/main/java/lumien/randomthings/RandomThings.java
+++ b/src/main/java/lumien/randomthings/RandomThings.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 
 import lumien.randomthings.asm.ClassTransformer;
-import lumien.randomthings.asm.CustomClassWriter;
 import lumien.randomthings.asm.confirmer.ServerConfirmer;
 import lumien.randomthings.biomes.ModBiomes;
 import lumien.randomthings.block.ModBlocks;
@@ -172,8 +171,6 @@ public class RandomThings implements LoadingCallback
 		asmConfirmer.confirm();
 
 		logger.log(Level.DEBUG, ClassTransformer.transformations + "/17 ASM Transformations were applied.");
-
-		CustomClassWriter.customClassLoader = null;
 
 		ModRecipes.addGlowingMushroomRecipes();
 

--- a/src/main/java/lumien/randomthings/asm/CustomClassWriter.java
+++ b/src/main/java/lumien/randomthings/asm/CustomClassWriter.java
@@ -1,7 +1,5 @@
 package lumien.randomthings.asm;
 
-import java.net.URLClassLoader;
-
 import org.objectweb.asm.ClassWriter;
 
 import net.minecraft.launchwrapper.Launch;
@@ -9,8 +7,6 @@ import net.minecraftforge.fml.common.asm.transformers.deobf.FMLDeobfuscatingRema
 
 public class CustomClassWriter extends ClassWriter
 {
-	public static URLClassLoader customClassLoader = new URLClassLoader(((URLClassLoader) Launch.classLoader.getClass().getClassLoader()).getURLs());
-
 	public CustomClassWriter(int flags)
 	{
 		super(flags);
@@ -28,15 +24,14 @@ public class CustomClassWriter extends ClassWriter
 		}
 
 		Class<?> c, d;
-		ClassLoader classLoader = customClassLoader;
 		try
 		{
-			c = Class.forName(type1.replace('/', '.'), false, classLoader);
-			d = Class.forName(type2.replace('/', '.'), false, classLoader);
+			c = Class.forName(type1.replace('/', '.'), false, Launch.classLoader);
+			d = Class.forName(type2.replace('/', '.'), false, Launch.classLoader);
 		}
 		catch (Exception e)
 		{
-			throw new RuntimeException(e.toString());
+			return "java/lang/Object";
 		}
 		if (c.isAssignableFrom(d))
 		{


### PR DESCRIPTION
CustomClassWriter's static initializer casts `Launch.classLoader.getClass().getClassLoader()` to `URLClassLoader` to create a custom class loader for `getCommonSuperClass()`. Since Java 9, the system class loader is no longer a `URLClassLoader`, so this cast throws a `ClassCastException` which permanently poisons the class with `NoClassDefFoundError`.

Every class the transformer touches (Block, World, EntityLivingBase, EntityRenderer, etc.) then fails to transform, which cascades into other mods' mixins failing too, ultimately crashing the game with `ClassNotFoundException: net.minecraft.client.Minecraft`.

The fix uses `Launch.classLoader` directly instead, which is the correct class loader that actually has Minecraft and mod classes. This also changes the catch block to return `java/lang/Object` instead of throwing, since some classes aren't loadable yet during early transformation (this is the same approach Mixin's own ClassWriter uses).

Works on both Java 8 and Java 9+. Tested on Cleanroom 0.5.12 with Java 25.