### PR TITLE
[Feature] Add option to disable Custom Workbenches

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The goal of Quantum Things is to provide continued support for Random Things, su
 - Added `/rt timeinabottle transfer <playername> <time><s|m|h|d>` to let players transfer their stored Time in a Bottle value to other players.
 - Added the ability to configure whether Spectre Illuminators should be disabled.
 - Added Spectre variants of Stairs, Fences, Fence Gates and Slabs.
+- Added the ability to configure whether Custom Workbenches should be disabled. ([courtesy of Bronitt](https://github.com/MagicJinn/Quantum-Things/pull/60))
 
 ### Fixes
 

--- a/src/main/java/lumien/randomthings/block/ModBlocks.java
+++ b/src/main/java/lumien/randomthings/block/ModBlocks.java
@@ -24,6 +24,7 @@ import lumien.randomthings.block.spectretree.BlockSpectrePlankSlab;
 import lumien.randomthings.block.spectretree.BlockSpectrePlankSlabDouble;
 import lumien.randomthings.block.spectretree.BlockSpectrePlankStairs;
 import lumien.randomthings.block.spectretree.BlockSpectreSapling;
+import lumien.randomthings.config.Features;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 public class ModBlocks
@@ -181,7 +182,10 @@ public class ModBlocks
 		specialChest = new BlockSpecialChest();
 		analogEmitter = new BlockAnalogEmitter();
 		fluidDisplay = new BlockFluidDisplay();
-		customWorkbench = new BlockCustomWorkbench();
+
+		if (!Features.DISABLE_CUSTOM_WORKBENCH)
+			customWorkbench = new BlockCustomWorkbench();
+
 		enderMailbox = new BlockEnderMailbox();
 		pitcherPlant = new BlockPitcherPlant();
 		platform = new BlockPlatform();

--- a/src/main/java/lumien/randomthings/client/models/ItemModels.java
+++ b/src/main/java/lumien/randomthings/client/models/ItemModels.java
@@ -50,7 +50,10 @@ public class ItemModels
 		registerBlock(ModBlocks.spectreBlock);
 		registerBlock(ModBlocks.analogEmitter);
 		registerBlock(ModBlocks.fluidDisplay);
-		registerBlock(ModBlocks.customWorkbench);
+
+		if (!Features.DISABLE_CUSTOM_WORKBENCH)
+			registerBlock(ModBlocks.customWorkbench);
+
 		registerBlock(ModBlocks.enderMailbox);
 		registerBlock(ModBlocks.pitcherPlant);
 		registerBlock(ModBlocks.specialChest);

--- a/src/main/java/lumien/randomthings/config/Features.java
+++ b/src/main/java/lumien/randomthings/config/Features.java
@@ -48,6 +48,9 @@ public class Features {
 	@ConfigOption(category = CATEGORY, name = "DisableSpectreIlluminator", comment = "Whether the Spectre Illuminator should be disabled. Removes the recipe and item from the game, as well as slightly improving TPS performance.")
 	public static boolean DISABLE_SPECTRE_ILLUMINATOR = false;
 
+	@ConfigOption(category = CATEGORY, name = "DisableCustomWorkbench", comment = "Whether the Custom Workbench should be disabled. Removes the recipe and item from the game.")
+	public static boolean DISABLE_CUSTOM_WORKBENCH = false;
+
 	@ConfigOption(category = CATEGORY, name = "LuminousBlocksEmitLight", comment = "Whether the Luminous and Luminous Translucent blocks should emit light.")
 	public static boolean LUMINOUS_BLOCKS_EMIT_LIGHT = false;
 

--- a/src/main/java/lumien/randomthings/config/ModConfiguration.java
+++ b/src/main/java/lumien/randomthings/config/ModConfiguration.java
@@ -230,6 +230,11 @@ public class ModConfiguration
 			if (disableSpectreIlluminatorProp != null) {
 				disableSpectreIlluminatorProp.setRequiresMcRestart(true);
 			}
+
+			Property disableCustomWorkbenchProp = configuration.getCategory(Features.CATEGORY).get("DisableCustomWorkbench");
+			if (disableCustomWorkbenchProp != null) {
+				disableCustomWorkbenchProp.setRequiresMcRestart(true);
+			}
 		}
 
 		if (configuration != null && configuration.hasCategory(Internals.CATEGORY)) {

--- a/src/main/java/lumien/randomthings/handler/RTEventHandler.java
+++ b/src/main/java/lumien/randomthings/handler/RTEventHandler.java
@@ -680,11 +680,13 @@ public class RTEventHandler {
 		event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:fluidDisplay", "inventory"),
 				modelFluidDisplay);
 
-		ModelCustomWorkbench modelCustomWorkbench = new ModelCustomWorkbench();
-		event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:customWorkbench", "normal"),
-				modelCustomWorkbench);
-		event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:customWorkbench", "inventory"),
-				modelCustomWorkbench);
+		if (!Features.DISABLE_CUSTOM_WORKBENCH) {
+			ModelCustomWorkbench modelCustomWorkbench = new ModelCustomWorkbench();
+			event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:customWorkbench", "normal"),
+					modelCustomWorkbench);
+			event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:customWorkbench", "inventory"),
+					modelCustomWorkbench);
+		}
 
 		ModelRune runeBaseModel = new ModelRune();
 		event.getModelRegistry().putObject(new ModelResourceLocation("randomthings:runeBase", "normal"), runeBaseModel);

--- a/src/main/java/lumien/randomthings/recipes/ModRecipes.java
+++ b/src/main/java/lumien/randomthings/recipes/ModRecipes.java
@@ -111,7 +111,8 @@ public class ModRecipes
 
 		ArrayUtils.reverse(oreDictDyes);
 
-		RecipeSorter.register("randomthings:customWorkbenchRecipe", RecipeWorkbench.class, Category.SHAPED, "");
+		if (!Features.DISABLE_CUSTOM_WORKBENCH)
+			RecipeSorter.register("randomthings:customWorkbenchRecipe", RecipeWorkbench.class, Category.SHAPED, "");
 
 		final ItemStack rottenFlesh = new ItemStack(Items.ROTTEN_FLESH);
 		final ItemStack boneMeal = new ItemStack(Items.DYE, 1, 15);
@@ -131,7 +132,8 @@ public class ModRecipes
 		final ItemStack glisteringMelon = new ItemStack(Items.SPECKLED_MELON);
 		final ItemStack witherSkull = new ItemStack(Items.SKULL, 1, 1);
 
-		ForgeRegistries.RECIPES.register(new RecipeWorkbench());
+		if (!Features.DISABLE_CUSTOM_WORKBENCH)
+			ForgeRegistries.RECIPES.register(new RecipeWorkbench());
 
 		// Imbuing Station
 		ImbuingRecipeHandler.addRecipe(waterBottle, vine, boneMeal, cobblestone, mossyCobblestone);

--- a/wiki/wiki_md/about/changelog.md
+++ b/wiki/wiki_md/about/changelog.md
@@ -7,6 +7,12 @@ category: about
 
 This page documents the changes and fixes made in Quantum Things, compared to the original Random Things mod, in reverse chronological order.
 
+## 1.2.3
+
+### Changes
+
+- Added the ability to configure whether Custom Workbenches should be disabled. ([courtesy of Bronitt](https://github.com/MagicJinn/Quantum-Things/pull/60))
+
 ## 1.2.2
 
 ### Fixes


### PR DESCRIPTION
Adds a new configuration option DISABLE_CUSTOM_WORKBENCH to Features.java that allows pack developers and server owners to completely disable custom workbenches made from various wood types.